### PR TITLE
Drop SYS_ADMIN capability.

### DIFF
--- a/sh/cmd/create.sh
+++ b/sh/cmd/create.sh
@@ -23,8 +23,6 @@ cmd_create() {
     # create a new container
     docker create --name=$CONTAINER --hostname=$CONTAINER \
         --restart=unless-stopped \
-        --cap-add SYS_ADMIN \
-        --security-opt apparmor:unconfined \
         --mount type=tmpfs,destination=/run \
         --mount type=tmpfs,destination=/run/lock \
         --mount type=bind,src=/sys/fs/cgroup,dst=/sys/fs/cgroup,readonly \


### PR DESCRIPTION
According to this article it is not needed if we use 'STOPSIGNAL SIGRTMIN+3'
https://developers.redhat.com/blog/2016/09/13/running-systemd-in-a-non-privileged-container/